### PR TITLE
Feature: add metadata about system application packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ RNAndroidPM.getPackageInfo('/storage/emulated/0/myapp.apk')
         versionCode: 3,
         firstInstallTime: 1185920,
         lastUpdateTime: 1283058,
+        isSystemApp: false
       }
     */
   })

--- a/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAndroidPackagemanagerModule.java
@@ -41,6 +41,7 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       int versionCode = pi.versionCode;
       long firstInstallTime = pi.firstInstallTime;
       long lastUpdateTime = pi.lastUpdateTime;
+      boolean isSystemApp = (ai.flags & ApplicationInfo.FLAG_SYSTEM) != 0;
 
       WritableMap info = Arguments.createMap();
       info.putString("package", pkg);
@@ -49,6 +50,7 @@ public class RNAndroidPackagemanagerModule extends ReactContextBaseJavaModule {
       info.putDouble("versionCode", versionCode);
       info.putDouble("firstInstallTime", firstInstallTime);
       info.putDouble("lastUpdateTime", lastUpdateTime);
+      info.putBoolean("isSystemApp", isSystemApp);
 
       promise.resolve(info);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export interface PackageInfo {
   versionCode: number;
   firstInstallTime: number;
   lastUpdateTime: number;
+  isSystemApp: boolean;
 }
 
 declare class RNAndroidPackagemanager {


### PR DESCRIPTION
Add `isSystemApp` property to `PackageInfo` class.
This property is based on the application flags. See: https://developer.android.com/reference/android/content/pm/ApplicationInfo.html#FLAG_SYSTEM for more information.

